### PR TITLE
Fix installation in virtualenv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ env/
 venv/
 ENV/
 env.bak/
+share/
 venv.bak/
 
 # Spyder project settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 zip-safe = false
+packages = ["pipforester"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md", "CHANGES.md", "LICENSE.md"], content-type = "text/markdown"}


### PR DESCRIPTION
```
$ python3.11 -mvenv .
$ bin/pip install -U pip setuptools wheel
$ bin/pip install -e .  # with or without -e makes no difference
Obtaining file:///Users/maurits/tmp/pipforester
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      /private/var/folders/26/1plvhxbs6yx7g_82v2xdxc500000gn/T/pip-build-env-ij4rb3ek/overlay/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
        warnings.warn(msg, _BetaConfiguration)
      error: Multiple top-level packages discovered in a flat-layout: ['lib', 'include', 'pipforester'].
      
      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.
      
      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:
      
      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names
      
      To find more information, look for "package discovery" on setuptools docs.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

This PR fixes it. Note: I am no expert on how to write pyproject.toml-only packages.